### PR TITLE
Require at least Julia 1.2 or greater

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,13 @@ os:
     # - osx
 
 julia:
-    - 1.1
-    # - nightly
+    - "1.2"
+    - nightly
 
 matrix:
     allow_failures:
         - julia: nightly
+        - os: osx
     fast_finish: true
 
 notifications:

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ authors = ["Dilum Aluthge <dilum@aluthge.com>"]
 version = "0.3.0"
 
 [compat]
-julia = "^1.1.0"
+julia = "^1.2.0"
 Traceur = "^0.3.0"
 
 [extras]


### PR DESCRIPTION
And drop support for Julia 1.1 and earlier