### PR TITLE
Add @ExtensibleUnion macro and @extensible function macro and members function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,8 @@ Create a new extensible union:
 
 Add methods that dispatch on extensible unions:
 ```julia
-f(x::MyUnion1, y, z, ...) = ...
-f(x, y::MyUnion2, z, ...) = ...
-extensiblefunction!(f, MyUnion1, MyUnion2, ...)
+@extensible f(x::MyUnion1, y, z, ...) = ... with MyUnion1
+@extensible f(x, y::MyUnion2, z, ...) = ... with MyUnion2
 ```
 
 Add types to an extensible union:
@@ -87,16 +86,10 @@ julia> describe(LadderTruck{Int}(2))
 julia> describe(WaterTender{Int}(3,4))
 "I don't know anything about this object"
 
-julia> describe(x::RedColorTrait) = "The color of this object is red"
+julia> @extensible describe(x::RedColorTrait) = "The color of this object is red" with RedColorTrait
 describe (generic function with 2 methods)
 
-julia> extensiblefunction!(describe, RedColorTrait)
-describe (generic function with 2 methods)
-
-julia> describe(x::BlueColorTrait) = "The color of this object is blue"
-describe (generic function with 3 methods)
-
-julia> extensiblefunction!(describe, BlueColorTrait)
+julia> @extensible describe(x::BlueColorTrait) = "The color of this object is blue" with BlueColorTrait
 describe (generic function with 3 methods)
 
 julia> methods(describe)

--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ TODO: Make this package thread-safe.
 
 Create a new extensible union:
 ```julia
-struct MyUnion end
-extensibleunion!(MyUnion)
+@ExtensibleUnion MyUnion
 ```
 
 Add methods that dispatch on extensible unions:
@@ -65,15 +64,9 @@ julia> mutable struct WaterTender{T} <: AbstractFireEngine
            y::T
        end
 
-julia> struct RedColorTrait end
+julia> @ExtensibleUnion RedColorTrait;
 
-julia> struct BlueColorTrait end
-
-julia> extensibleunion!(RedColorTrait)
-RedColorTrait
-
-julia> extensibleunion!(BlueColorTrait)
-BlueColorTrait
+julia> @ExtensibleUnion BlueColorTrait;
 
 julia> describe(x) = "I don't know anything about this object"
 describe (generic function with 1 method)

--- a/README.md
+++ b/README.md
@@ -22,9 +22,10 @@ Create a new extensible union:
 
 Add methods that dispatch on extensible unions:
 ```julia
-@extensible f(x::MyUnion1, y, z, ...) = ... with MyUnion1
-@extensible f(x, y::MyUnion2, z, ...) = ... with MyUnion2
+@extensible f(x::{MyUnion1}, y, z, ...) = ...
+@extensible f(x, y::{MyUnion2}, z, ...) = ...
 ```
+Curly braces in the macro denote an extensible union.
 
 Add types to an extensible union:
 ```julia
@@ -86,10 +87,10 @@ julia> describe(LadderTruck{Int}(2))
 julia> describe(WaterTender{Int}(3,4))
 "I don't know anything about this object"
 
-julia> @extensible describe(x::RedColorTrait) = "The color of this object is red" with RedColorTrait
+julia> @extensible describe(x::{RedColorTrait}) = "The color of this object is red"
 describe (generic function with 2 methods)
 
-julia> @extensible describe(x::BlueColorTrait) = "The color of this object is blue" with BlueColorTrait
+julia> @extensible describe(x::{BlueColorTrait}) = "The color of this object is blue"
 describe (generic function with 3 methods)
 
 julia> methods(describe)

--- a/src/ExtensibleUnions.jl
+++ b/src/ExtensibleUnions.jl
@@ -3,12 +3,16 @@ module ExtensibleUnions
 export addtounion!, # extensible_unions.jl
        extensiblefunction!, # extensible_functions.jl
        extensibleunion!, # extensible_unions.jl
+       @ExtensibleUnion, # extensible_unions.jl
+       ExtensibleUnion,  # extensible_unions.jl
+       members,          # extensible_unions.jl
        isextensiblefunction, # extensible_functions.jl
        isextensibleunion # extensible_unions.jl
 
 const _registry_extensibleunion_to_genericfunctions = Dict{Any, Any}()
-const _registry_extensibleunion_to_members = Dict{Any, Any}()
+const _registry_extensibleunion_to_members = Dict{Type, Set{Type}}()
 const _registry_genericfunctions_to_extensibleunions = Dict{Any, Any}()
+
 
 include("code_transformation.jl")
 include("extensible_functions.jl")

--- a/src/ExtensibleUnions.jl
+++ b/src/ExtensibleUnions.jl
@@ -7,6 +7,7 @@ export addtounion!, # extensible_unions.jl
        ExtensibleUnion,  # extensible_unions.jl
        members,          # extensible_unions.jl
        isextensiblefunction, # extensible_functions.jl
+       @extensible,      # extensible_functions.jl
        isextensibleunion # extensible_unions.jl
 
 const _registry_extensibleunion_to_genericfunctions = Dict{Any, Any}()

--- a/src/extensible_functions.jl
+++ b/src/extensible_functions.jl
@@ -30,7 +30,7 @@ function isextensiblefunction(@nospecialize(f::Function))
 end
 
 macro extensible(fdef)
-    @assert fdef.head = :(=) || fdef.head == :(:function)
+    @assert fdef.head == :(=) || fdef.head == :(:function)
     ext_unions = Symbol[]
     name  = fdef.args[1].args[1]
     fargs = fdef.args[1].args[2:end]

--- a/src/extensible_functions.jl
+++ b/src/extensible_functions.jl
@@ -30,6 +30,7 @@ function isextensiblefunction(@nospecialize(f::Function))
 end
 
 macro extensible(fdef)
+    @assert fdef.head = :(=) || fdef.head == :(:function)
     ext_unions = Symbol[]
     name  = fdef.args[1].args[1]
     fargs = fdef.args[1].args[2:end]
@@ -48,6 +49,3 @@ macro extensible(fdef)
         extensiblefunction!($name, $(ext_unions...))
     end |> esc
 end
-
-
-

--- a/src/extensible_functions.jl
+++ b/src/extensible_functions.jl
@@ -28,3 +28,14 @@ function isextensiblefunction(@nospecialize(f::Function))
     global _registry_genericfunctions_to_extensibleunions
     return haskey(_registry_genericfunctions_to_extensibleunions, f)
 end
+
+macro extensible(fdef, with, Us...)
+    @assert with == :with
+    quote
+        $fdef
+        extensiblefunction!($(fdef.args[1].args[1]), $(Us...))
+    end |> esc
+end
+
+
+

--- a/src/update_methods.jl
+++ b/src/update_methods.jl
@@ -134,8 +134,7 @@ function _replace_types(sig::Type{<:Tuple})
     return Tuple{v...}
 end
 
-@inline _replace_types(sig::UnionAll, p::Pair) = _replace_types(sig.body, p)
-@inline _replace_types(sig::TypeVar,  p::Pair) = _replace_types(sig.ub,   p)
+@inline _replace_types(sig::TypeVar,  p::Pair) = _replace_types(sig.ub, p)
 function _replace_types(sig::Type{<:Tuple}, p::Pair)
     v = Any[_peel_unionall(sig).types...]
     for i = 2:length(v)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,15 @@ using ExtensibleUnions
 using Test
 using Traceur
 
+macro genstruct!(list, super)
+    x = gensym()
+    y = quote
+        struct $(x) <: $super end
+        push!($(list), $(x))
+    end
+    return y
+end
+
 macro genstruct!(list)
     x = gensym()
     y = quote

--- a/test/test_examples.jl
+++ b/test/test_examples.jl
@@ -19,11 +19,8 @@ mutable struct WaterTender{T} <: AbstractFireEngine
     y::T
 end
 
-struct RedColorTrait end
-struct BlueColorTrait end
-
-extensibleunion!(RedColorTrait)
-extensibleunion!(BlueColorTrait)
+@ExtensibleUnion RedColorTrait
+@ExtensibleUnion BlueColorTrait
 
 describe(x) = "I don't know anything about this object"
 

--- a/test/test_extensible_functions.jl
+++ b/test/test_extensible_functions.jl
@@ -1,7 +1,7 @@
 using ExtensibleUnions
 using Test
 
-struct S5 end
+struct S5 <: ExtensibleUnion end
 function f1 end
 @test !isextensibleunion(S5)
 @test !isextensiblefunction(f1)

--- a/test/test_extensible_unions.jl
+++ b/test/test_extensible_unions.jl
@@ -19,7 +19,7 @@ struct S3 <: A2
 end
 @test_throws ArgumentError extensibleunion!(S3)
 
-struct S4 end
+struct S4 <: ExtensibleUnion end
 @test !isextensibleunion(S4)
 extensibleunion!(S4)
 @test isextensibleunion(S4)
@@ -28,14 +28,12 @@ extensibleunion!(S4)
 extensibleunion!(S4)
 @test isextensibleunion(S4)
 
-struct S6 end
-extensibleunion!(S6)
+@ExtensibleUnion S6
 @test !ExtensibleUnions.unioncurrentlycontains(S6, String)
 addtounion!(S6, String)
 @test ExtensibleUnions.unioncurrentlycontains(S6, String)
 
-struct S7 end
-extensibleunion!(S7)
+@ExtensibleUnion S7
 @test !ExtensibleUnions.unioncurrentlycontains(S7, String)
 addtounion!(S7, String)
 @test ExtensibleUnions.unioncurrentlycontains(S7, String)
@@ -45,18 +43,19 @@ struct S8 end
 @test_throws ArgumentError ExtensibleUnions.unioncurrentlycontains(S8, String)
 
 let
-    struct MyUnion end
-    extensibleunion!(MyUnion)
-
-    struct Foo end
-    addtounion!(MyUnion, Foo)
+    @ExtensibleUnion S9
+    
+    struct S10 end
+    addtounion!(S9, S10)
 
     foo(x::Tuple{Int, T}) where {T} = x[1]
 
-    foo(::MyUnion) = "boo!"
-    extensiblefunction!(foo, MyUnion)
+    foo(::S9) = "boo!"
+    extensiblefunction!(foo, S9)
 
-    @test foo(Foo()) == "boo!"
+    @test foo(S10())  == "boo!"
+    @test members(S9) == [S10]
+    @test repr(S9)   == "Extensible Union S9 with members: S10."
 end
 
 let

--- a/test/test_extensible_unions.jl
+++ b/test/test_extensible_unions.jl
@@ -50,8 +50,7 @@ let
 
     foo(x::Tuple{Int, T}) where {T} = x[1]
 
-    foo(::S9) = "boo!"
-    extensiblefunction!(foo, S9)
+    @extensible foo(::S9) = "boo!" with S9
 
     @test foo(S10())  == "boo!"
     @test members(S9) == [S10]

--- a/test/test_extensible_unions.jl
+++ b/test/test_extensible_unions.jl
@@ -50,7 +50,7 @@ let
 
     foo(x::Tuple{Int, T}) where {T} = x[1]
 
-    @extensible foo(::S9) = "boo!" with S9
+    @extensible foo(::{S9}) = "boo!"
 
     @test foo(S10())  == "boo!"
     @test members(S9) == [S10]

--- a/test/test_update_methods.jl
+++ b/test/test_update_methods.jl
@@ -26,9 +26,9 @@ b = Type{Vector{T} where T}
 @test ExtensibleUnions._replace_types(Union{Int32, Float32, AbstractString, Symbol}, Union{Int32, Float32, AbstractString, Symbol} => Union{Int32, Float32, AbstractString, Symbol, Char}) == Union{Int32, Float32, AbstractString, Symbol, Char}
 
 structlist = Any[]
-@genstruct!(structlist)
-@genstruct!(structlist)
-@genstruct!(structlist)
+@genstruct!(structlist, ExtensibleUnion)
+@genstruct!(structlist, ExtensibleUnion)
+@genstruct!(structlist, ExtensibleUnion)
 @genstruct!(structlist)
 @genstruct!(structlist)
 @genstruct!(structlist)


### PR DESCRIPTION
closes #51, closes #16 

This PR implementes two new macros and a function. Here's an example them it in use:

```julia
julia> using ExtensibleUnions

julia> @ExtensibleUnion MyUnion
Extensible Union MyUnion with no members.

julia> struct Foo end; struct Bar end;

julia> addtounion!(MyUnion, Foo, Bar)
Extensible Union MyUnion with members: Bar, Foo.

julia> members(MyUnion)
2-element Array{Type,1}:
 Bar
 Foo

julia> @extensible function f(::{MyUnion})
           "hi"
       end
f (generic function with 1 method)

julia> @extensible f(x::{MyUnion}, y::String) = "hi"*y
f (generic function with 2 methods)

julia> f(Foo(), "bye")
"hibye"
```
In the macro `@extensible`, when you wrap a type argument in curly braces, that marks it as a union to be included in a `extensiblefunction!(f, unions...)` call.

The other major change is that I made an abstract type `ExtensibleUnion` which all extensible unions must be a subtype of (instead of Any).
